### PR TITLE
Added missing hashtag to _create_config

### DIFF
--- a/redoflacs
+++ b/redoflacs
@@ -734,7 +734,7 @@ SOURCE
 MASTERING
 
 # The REPLAYGAIN tags below, are added by the '-g, --replaygain' or
-'-G, --replaygain-noforce' argument.  If you want to keep the ReplayGain tags,
+#'-G, --replaygain-noforce' argument.  If you want to keep the ReplayGain tags,
 # make sure you leave these here.
 REPLAYGAIN_REFERENCE_LOUDNESS
 REPLAYGAIN_TRACK_GAIN


### PR DESCRIPTION
Was reading through the config and noticed a line missing a hashtag that I assume is not meant to be interpreted.